### PR TITLE
Remove unwrap to avoid panic

### DIFF
--- a/src/json/de.rs
+++ b/src/json/de.rs
@@ -394,7 +394,7 @@ impl<'de> JsonDeserializer<'de> {
     }
 
     fn parse_string(&mut self) -> Result<String, DecodeJsonError> {
-        self.expect(0x22, ErrorCode::ExpectedString).unwrap();
+        self.expect(0x22, ErrorCode::ExpectedString)?;
 
         let mut decoded = String::new();
 


### PR DESCRIPTION
A failed attempt to parse a string during deserialization results in a panic on unwrap (ie. when the given type is not a string). For example, if the `author` field of a message is the number `42`:

```shell
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: DecodeJsonError { code: ExpectedString, position: 10 }', /home/glyph/.cargo/registry/src/github.com-1ecc6299db9ec823/ssb-legacy-msg-data-0.1.2/src/json/de.rs:397:54
```

This PR simply replaces `unwrap()` with the `?` operator to return the appropriate variant for the custom error type `DecodeJsonError`. In this case the variant is `ExpectedString`.