### PR TITLE
Remove redundant box check for content string

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -186,12 +186,7 @@ impl<'de> Visitor<'de> for ContentValueVisitor {
     }
 
     fn visit_string<E: Error>(self, v: String) -> Result<Self::Value, E> {
-        // check whether the given string represents an encoded private message
-        if v.contains(".box") {
-            Ok(ContentValue(Value::String(v)))
-        } else {
-            Err(E::custom("content string must contain `.box`"))
-        }
+        Ok(ContentValue(Value::String(v)))
     }
 
     fn visit_map<A>(mut self, mut map: A) -> Result<Self::Value, A::Error>


### PR DESCRIPTION
Remove the check for `.box` if the message `content` field is a string (in other words, an encrypted private message). This check has been made redundant by the canonical base64 Regex match introduced in https://github.com/mycognosist/ssb-validate/pull/7